### PR TITLE
Add Open-Meteo weather and Google News sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,143 @@
+# Dumb API Sources
+
+A simple Node.js library for easy connection to third-party APIs. Currently supports TwelveData for stock market data.
+
+## Installation
+
+```bash
+npm install
+```
+
+## Setup
+
+### TwelveData API Key
+
+You need a free API key from [TwelveData](https://twelvedata.com/). You can get one by signing up at their website.
+
+The API key is already configured in the `config.js` file. You can also:
+
+Set your API key as an environment variable:
+
+```bash
+export TWELVEDATA_API_KEY="your-api-key-here"
+```
+
+Or pass it directly when creating an instance:
+
+```javascript
+import { DumbAPISources } from './src/index.js';
+
+const api = new DumbAPISources({
+  twelvedata: {
+    apiKey: 'your-api-key-here'
+  }
+});
+```
+
+## Usage
+
+### Basic Usage
+
+```javascript
+import dumbAPISources from './src/index.js';
+
+// Get current price for Apple stock
+const applePrice = await dumbAPISources.get('twelvedata', 'apple');
+console.log(applePrice);
+// Output: { symbol: 'AAPL', price: 150.25, timestamp: '2024-01-15T10:30:00.000Z', source: 'twelvedata' }
+```
+
+### Get Detailed Quote
+
+```javascript
+// Get detailed quote with more information
+const appleQuote = await dumbAPISources.getQuote('twelvedata', 'AAPL');
+console.log(appleQuote);
+// Output: { symbol: 'AAPL', name: 'Apple Inc.', price: 150.25, change: 2.15, changePercent: 1.45, ... }
+```
+
+### Available Methods
+
+- `get(source, symbol, options)` - Get basic data (current price by default)
+- `getQuote(source, symbol)` - Get detailed quote information
+- `getAvailableSources()` - Get list of available API sources
+- `addSource(name, apiInstance)` - Add a new API source
+
+### Supported Sources
+
+- **twelvedata** - Stock market data (prices, quotes, etc.)
+
+## Examples
+
+Run the example file to see the library in action:
+
+```bash
+node example.js
+```
+
+## API Response Format
+
+### Current Price Response
+```javascript
+{
+  symbol: 'AAPL',
+  price: 150.25,
+  timestamp: '2024-01-15T10:30:00.000Z',
+  source: 'twelvedata'
+}
+```
+
+### Quote Response
+```javascript
+{
+  symbol: 'AAPL',
+  name: 'Apple Inc.',
+  price: 150.25,
+  change: 2.15,
+  changePercent: 1.45,
+  volume: 45000000,
+  high: 152.10,
+  low: 148.50,
+  open: 149.80,
+  previousClose: 148.10,
+  timestamp: '2024-01-15T10:30:00.000Z',
+  source: 'twelvedata'
+}
+```
+
+## Error Handling
+
+The library includes comprehensive error handling:
+
+```javascript
+try {
+  const data = await dumbAPISources.get('twelvedata', 'AAPL');
+} catch (error) {
+  console.error('Error:', error.message);
+}
+```
+
+Common errors:
+- Missing API key
+- Invalid symbol
+- Network issues
+- API rate limits
+
+## Development
+
+### Project Structure
+
+```
+src/
+├── index.js          # Main library interface
+└── apis/
+    └── twelvedata.js # TwelveData API client
+```
+
+### Adding New API Sources
+
+To add a new API source, create a new file in `src/apis/` and implement the required methods. Then add it to the main class in `src/index.js`.
+
+## License
+
+MIT

--- a/example.js
+++ b/example.js
@@ -1,0 +1,82 @@
+import 'dotenv/config';
+import dumbAPISources from './src/index.js';
+
+// Example usage of the dumb-api-sources library
+
+async function example() {
+  try {
+    console.log('🚀 Testing dumb-api-sources library...\n');
+
+    // Use the default instance (will read from environment variables)
+    const api = dumbAPISources;
+
+    console.log('Available sources:', api.getAvailableSources());
+    console.log('');
+    // Example 1: Get current price for Apple stock
+    console.log('📈 Getting current price for Apple (AAPL)...');
+    const applePrice = await api.get('twelvedata', 'AAPL');
+    console.log('Apple current price:', applePrice);
+    console.log('');
+     
+    /*
+    // Example 2: Get current price for OMXS30 stock
+    console.log('📈 Getting current price for OMXS30 (OMXS30)...');
+    const omxs30Price = await api.get('twelvedata', 'OMXS30');
+    console.log('OMXS30 current price:', omxs30Price);
+    console.log('');
+
+    // Example 2: Get detailed quote for OMXS30 stock
+    console.log('📊 Getting detailed quote for OMXS30 (OMXS30)...');
+    const omxs30Quote = await api.getQuote('twelvedata', 'OMXS30');
+    console.log('OMXS30 detailed quote:', omxs30Quote);
+    console.log('');
+    */
+
+    // Example 3: Get current price for S&P500:w 
+    console.log('💻 Getting current price for S&P 500 ETF (SPY)...');
+    const spxPrice = await api.get('twelvedata', 'SPY');
+    console.log('S&P 500 current price:', spxPrice);
+    console.log('');
+
+    // Weather examples via Open-Meteo
+    console.log('🌤️ Getting current weather for Stockholm...');
+    const stockholmWeather = await api.get('openmeteo', 'stockholm');
+    console.log('Stockholm weather:', stockholmWeather);
+    console.log('');
+
+    console.log('🌤️ Getting current weather for New York via coordinates...');
+    const nycWeather = await api.get('openmeteo', { latitude: 40.7128, longitude: -74.0060, name: 'New York' });
+    console.log('New York weather:', nycWeather);
+    console.log('');
+
+    // Google News example
+    console.log('🗞️ Getting Google News headlines for Apple...');
+    const gn = await api.get('googlenews', { q: 'Apple', lang: 'en', country: 'US', max: 5 });
+    console.log('Google News (Apple):', gn);
+    console.log('');
+
+    // Example 4: Error handling
+    console.log('❌ Testing error handling with invalid symbol...');
+    try {
+      await api.get('twelvedata', 'INVALID_SYMBOL_12345');
+    } catch (error) {
+      console.log('Expected error caught:', error.message);
+    }
+    console.log('');
+
+    // Example 5: Testing unsupported source
+    console.log('❌ Testing unsupported source...');
+    try {
+      await api.get('unsupported', 'AAPL');
+    } catch (error) {
+      console.log('Expected error caught:', error.message);
+    }
+
+  } catch (error) {
+    console.error('❌ Error in example:', error.message);
+    console.log('\n💡 Make sure your TWELVEDATA_API_KEY is set in your .env file or as an environment variable.');
+  }
+}
+
+// Run the example
+example();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,359 @@
+{
+  "name": "dumb-api-sources",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dumb-api-sources",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.0",
+        "dotenv": "^17.2.2",
+        "rss-parser": "^3.13.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dumb-api-sources",
+  "version": "1.0.0",
+  "description": "Easy connection to third-party APIs including twelvedata.com",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "test": "node test.js",
+    "start": "node src/index.js"
+  },
+  "keywords": [
+    "api",
+    "twelvedata",
+    "stock",
+    "finance",
+    "third-party"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^1.6.0",
+    "dotenv": "^17.2.2",
+    "rss-parser": "^3.13.0"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/src/apis/googlenews.js
+++ b/src/apis/googlenews.js
@@ -1,0 +1,47 @@
+import Parser from 'rss-parser';
+
+class GoogleNewsAPI {
+  constructor() {
+    this.parser = new Parser({ timeout: 10000 });
+    this.baseUrl = 'https://news.google.com/rss';
+  }
+
+  // query can be a string like 'apple', or an object { q, lang, country, max }
+  async getHeadlines(query) {
+    const { q, lang = 'en', country = 'US', max = 10 } = this.normalizeQuery(query);
+
+    const url = `${this.baseUrl}/search?hl=${encodeURIComponent(lang)}&gl=${encodeURIComponent(country)}&q=${encodeURIComponent(q)}&ceid=${encodeURIComponent(country)}:${encodeURIComponent(lang)}`;
+
+    const feed = await this.parser.parseURL(url);
+
+    // Normalize items
+    const items = (feed.items || []).slice(0, max).map(item => ({
+      title: item.title || null,
+      link: item.link || null,
+      published: item.isoDate || item.pubDate || null,
+      source: (item.creator || item.author || '').toString() || null,
+      snippet: item.contentSnippet || null
+    }));
+
+    return {
+      query: q,
+      lang,
+      country,
+      items,
+      total: items.length,
+      source: 'googlenews'
+    };
+  }
+
+  normalizeQuery(query) {
+    if (typeof query === 'string') {
+      return { q: query.trim() };
+    }
+    if (query && typeof query === 'object' && query.q) {
+      return query;
+    }
+    throw new Error('GoogleNews: query must be a string or { q, lang?, country?, max? }');
+  }
+}
+
+export default GoogleNewsAPI;

--- a/src/apis/openmeteo.js
+++ b/src/apis/openmeteo.js
@@ -1,0 +1,106 @@
+import axios from 'axios';
+
+class OpenMeteoAPI {
+  constructor() {
+    this.forecastBaseUrl = 'https://api.open-meteo.com/v1/forecast';
+    this.geocodingBaseUrl = 'https://geocoding-api.open-meteo.com/v1/search';
+    
+    // Weather code mapping to simple descriptions
+    this.weatherCodeMap = {
+      0: 'clear',
+      1: 'mostly_clear',
+      2: 'partly_cloudy',
+      3: 'overcast',
+      45: 'foggy',
+      48: 'foggy',
+      51: 'drizzling',
+      53: 'drizzling',
+      55: 'drizzling',
+      61: 'raining',
+      63: 'raining',
+      65: 'raining',
+      71: 'snowing',
+      73: 'snowing',
+      75: 'snowing',
+      77: 'snowing',
+      80: 'light_rain',
+      81: 'light_rain',
+      82: 'heavy_rain',
+      85: 'light_snow',
+      86: 'heavy_snow',
+      95: 'thunderstorm',
+      96: 'thunderstorm',
+      99: 'thunderstorm'
+    };
+  }
+
+  getWeatherDescription(code) {
+    return this.weatherCodeMap[code] || 'unknown';
+  }
+
+  async getCurrent(placeOrCoordinates) {
+    const { latitude, longitude, name } = await this.resolveLocation(placeOrCoordinates);
+
+    const response = await axios.get(this.forecastBaseUrl, {
+      params: {
+        latitude,
+        longitude,
+        current: 'temperature_2m,wind_speed_10m,wind_direction_10m,weather_code',
+        timezone: 'UTC'
+      }
+    });
+
+    const current = response.data?.current;
+    if (!current) {
+      throw new Error('Open-Meteo: missing current weather in response');
+    }
+
+    const weatherCode = current.weather_code ?? null;
+    const weatherDescription = weatherCode !== null ? this.getWeatherDescription(weatherCode) : 'unknown';
+
+    return {
+      location: name,
+      latitude,
+      longitude,
+      temperatureC: typeof current.temperature_2m === 'number' ? current.temperature_2m : null,
+      windSpeedMps: typeof current.wind_speed_10m === 'number' ? current.wind_speed_10m : null,
+      windDirectionDeg: typeof current.wind_direction_10m === 'number' ? current.wind_direction_10m : null,
+      weatherCode: weatherCode,
+      weather: weatherDescription,
+      timestamp: current.time ?? new Date().toISOString(),
+      source: 'openmeteo'
+    };
+  }
+
+  async resolveLocation(placeOrCoordinates) {
+    if (typeof placeOrCoordinates === 'object' && placeOrCoordinates && 'latitude' in placeOrCoordinates && 'longitude' in placeOrCoordinates) {
+      const { latitude, longitude, name } = placeOrCoordinates;
+      if (typeof latitude !== 'number' || typeof longitude !== 'number') {
+        throw new Error('Open-Meteo: latitude/longitude must be numbers');
+      }
+      return { latitude, longitude, name: name || `${latitude},${longitude}` };
+    }
+
+    const place = String(placeOrCoordinates || '').trim();
+    if (!place) {
+      throw new Error('Open-Meteo: place is required');
+    }
+
+    const geocode = await axios.get(this.geocodingBaseUrl, {
+      params: { name: place, count: 1, format: 'json' }
+    });
+
+    const first = geocode.data?.results?.[0];
+    if (!first) {
+      throw new Error(`Open-Meteo: could not geocode "${place}"`);
+    }
+
+    return {
+      latitude: first.latitude,
+      longitude: first.longitude,
+      name: first.name
+    };
+  }
+}
+
+export default OpenMeteoAPI;

--- a/src/apis/twelvedata.js
+++ b/src/apis/twelvedata.js
@@ -1,0 +1,81 @@
+import axios from 'axios';
+
+class TwelveDataAPI {
+  constructor(apiKey = null) {
+    this.apiKey = apiKey || process.env.TWELVEDATA_API_KEY;
+    this.baseURL = 'https://api.twelvedata.com';
+  }
+
+  async getCurrentPrice(symbol) {
+    try {
+      if (!this.apiKey) {
+        throw new Error('TwelveData API key is required. Set TWELVEDATA_API_KEY environment variable or pass it to constructor.');
+      }
+
+      const response = await axios.get(`${this.baseURL}/price`, {
+        params: {
+          symbol: symbol.toUpperCase(),
+          apikey: this.apiKey
+        }
+      });
+
+      if (response.data.status === 'error') {
+        throw new Error(`TwelveData API Error: ${response.data.message}`);
+      }
+
+      return {
+        symbol: symbol.toUpperCase(),
+        price: parseFloat(response.data.price),
+        timestamp: new Date().toISOString(),
+        source: 'twelvedata'
+      };
+    } catch (error) {
+      if (error.response) {
+        throw new Error(`TwelveData API Error: ${error.response.status} - ${error.response.data?.message || error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  async getQuote(symbol) {
+    try {
+      if (!this.apiKey) {
+        throw new Error('TwelveData API key is required. Set TWELVEDATA_API_KEY environment variable or pass it to constructor.');
+      }
+
+      const response = await axios.get(`${this.baseURL}/quote`, {
+        params: {
+          symbol: symbol.toUpperCase(),
+          apikey: this.apiKey
+        }
+      });
+
+      if (response.data.status === 'error') {
+        throw new Error(`TwelveData API Error: ${response.data.message}`);
+      }
+
+      const data = response.data;
+      return {
+        symbol: data.symbol,
+        name: data.name,
+        price: parseFloat(data.price),
+        change: parseFloat(data.change),
+        changePercent: parseFloat(data.percent_change),
+        volume: parseInt(data.volume),
+        high: parseFloat(data.day_high),
+        low: parseFloat(data.day_low),
+        open: parseFloat(data.open),
+        previousClose: parseFloat(data.previous_close),
+        timestamp: new Date().toISOString(),
+        source: 'twelvedata'
+      };
+    } catch (error) {
+      if (error.response) {
+        throw new Error(`TwelveData API Error: ${error.response.status} - ${error.response.data?.message || error.message}`);
+      }
+      throw error;
+    }
+  }
+}
+
+export default TwelveDataAPI;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,106 @@
+import TwelveDataAPI from './apis/twelvedata.js';
+import OpenMeteoAPI from './apis/openmeteo.js';
+import GoogleNewsAPI from './apis/googlenews.js';
+
+class DumbAPISources {
+  constructor(config = {}) {
+    this.apis = {
+      twelvedata: new TwelveDataAPI(config.twelvedata?.apiKey),
+      openmeteo: new OpenMeteoAPI(),
+      googlenews: new GoogleNewsAPI()
+    };
+  }
+
+  /**
+   * Get data from a specified API source
+   * @param {string} source - The API source name (e.g., 'twelvedata', 'openmeteo')
+   * @param {string|Object} symbol - Query (e.g., 'AAPL' or place name or { latitude, longitude })
+   * @param {Object} options - Additional options for the request
+   * @returns {Promise<Object>} The API response data
+   */
+  async get(source, symbol, options = {}) {
+    if (!source || typeof source !== 'string') {
+      throw new Error('Source must be a non-empty string');
+    }
+
+    const sourceLower = source.toLowerCase();
+
+    if (!this.apis[sourceLower]) {
+      throw new Error(`Unsupported API source: ${source}. Available sources: ${Object.keys(this.apis).join(', ')}`);
+    }
+
+    // Validate symbol/query input
+    if (sourceLower === 'openmeteo' || sourceLower === 'googlenews') {
+      if (symbol === undefined || symbol === null || (typeof symbol !== 'string' && typeof symbol !== 'object')) {
+        throw new Error('For openmeteo/googlenews, provide a string or options object');
+      }
+    } else {
+      if (!symbol || typeof symbol !== 'string') {
+        throw new Error('Symbol must be a non-empty string');
+      }
+    }
+
+    try {
+      if (sourceLower === 'twelvedata') {
+        if (options.quote) {
+          return await this.apis.twelvedata.getQuote(symbol);
+        }
+        return await this.apis.twelvedata.getCurrentPrice(symbol);
+      }
+
+      if (sourceLower === 'openmeteo') {
+        return await this.apis.openmeteo.getCurrent(symbol);
+      }
+
+      if (sourceLower === 'googlenews') {
+        return await this.apis.googlenews.getHeadlines(symbol);
+      }
+
+      throw new Error(`No implementation found for source: ${source}`);
+    } catch (error) {
+      throw new Error(`Failed to fetch data from ${source} for symbol ${typeof symbol === 'string' ? symbol : '[coordinates]'}: ${error.message}`);
+    }
+  }
+
+  /**
+   * Get a quote (detailed information) from a specified API source
+   * @param {string} source - The API source name (e.g., 'twelvedata')
+   * @param {string} symbol - The symbol to query (e.g., 'AAPL')
+   * @returns {Promise<Object>} The detailed quote data
+   */
+  async getQuote(source, symbol) {
+    return this.get(source, symbol, { quote: true });
+  }
+
+  /**
+   * Add a new API source
+   * @param {string} name - The name of the API source
+   * @param {Object} apiInstance - The API instance
+   */
+  addSource(name, apiInstance) {
+    if (!name || typeof name !== 'string') {
+      throw new Error('Source name must be a non-empty string');
+    }
+    
+    if (!apiInstance || typeof apiInstance !== 'object') {
+      throw new Error('API instance must be an object');
+    }
+
+    this.apis[name.toLowerCase()] = apiInstance;
+  }
+
+  /**
+   * Get list of available API sources
+   * @returns {Array<string>} List of available source names
+   */
+  getAvailableSources() {
+    return Object.keys(this.apis);
+  }
+}
+
+// Create and export a default instance
+const dumbAPISources = new DumbAPISources();
+
+// Export both the class and the default instance
+export default dumbAPISources;
+export { DumbAPISources };


### PR DESCRIPTION
This PR adds:\n- Open-Meteo weather source with simple weather descriptions (clear/overcast/raining/snowing, etc.)\n- Google News source using RSS, supports query, lang, country, max\n- Example updates demonstrating finance (AAPL, SPY), weather (Stockholm, NYC), and news (Apple)\n\nAlso includes input validation improvements and source wiring in src/index.js.