### PR TITLE
Docs: add inputs/outputs for all sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Dumb API Sources
 
-A simple Node.js library for easy connection to third-party APIs. Currently supports TwelveData for stock market data.
+A simple Node.js library for easy connection to third-party APIs.
+
+Currently supported sources:
+- TwelveData (stocks, quotes)
+- Open‑Meteo (current weather)
+- Google News (RSS headlines)
 
 ## Installation
 
@@ -11,133 +16,152 @@ npm install
 ## Setup
 
 ### TwelveData API Key
-
-You need a free API key from [TwelveData](https://twelvedata.com/). You can get one by signing up at their website.
-
-The API key is already configured in the `config.js` file. You can also:
+You need a free API key from `twelvedata.com`.
 
 Set your API key as an environment variable:
-
 ```bash
 export TWELVEDATA_API_KEY="your-api-key-here"
 ```
 
 Or pass it directly when creating an instance:
-
 ```javascript
 import { DumbAPISources } from './src/index.js';
 
 const api = new DumbAPISources({
-  twelvedata: {
-    apiKey: 'your-api-key-here'
-  }
+  twelvedata: { apiKey: 'your-api-key-here' }
 });
 ```
 
+Open‑Meteo and Google News do not require API keys.
+
 ## Usage
 
-### Basic Usage
-
 ```javascript
+import 'dotenv/config';
 import dumbAPISources from './src/index.js';
 
-// Get current price for Apple stock
-const applePrice = await dumbAPISources.get('twelvedata', 'apple');
-console.log(applePrice);
-// Output: { symbol: 'AAPL', price: 150.25, timestamp: '2024-01-15T10:30:00.000Z', source: 'twelvedata' }
+// TwelveData: current price
+const aapl = await dumbAPISources.get('twelvedata', 'AAPL');
+// => { symbol, price, timestamp, source: 'twelvedata' }
+
+// TwelveData: detailed quote
+const aaplQuote = await dumbAPISources.getQuote('twelvedata', 'AAPL');
+// => { symbol, name, price, change, changePercent, volume, high, low, open, previousClose, timestamp, source }
+
+// Open‑Meteo: weather by place name
+const stockholm = await dumbAPISources.get('openmeteo', 'stockholm');
+// => { location, latitude, longitude, temperatureC, windSpeedMps, windDirectionDeg, weatherCode, weather, timestamp, source: 'openmeteo' }
+
+// Open‑Meteo: weather by coordinates
+const nyc = await dumbAPISources.get('openmeteo', { latitude: 40.7128, longitude: -74.0060, name: 'New York' });
+
+// Google News: headlines by query (locale optional)
+const appleNews = await dumbAPISources.get('googlenews', { q: 'Apple', lang: 'en', country: 'US', max: 5 });
+// => { query, lang, country, items: [{ title, link, published, source, snippet }], total, source: 'googlenews' }
 ```
 
-### Get Detailed Quote
+## API Details (Inputs/Outputs)
 
-```javascript
-// Get detailed quote with more information
-const appleQuote = await dumbAPISources.getQuote('twelvedata', 'AAPL');
-console.log(appleQuote);
-// Output: { symbol: 'AAPL', name: 'Apple Inc.', price: 150.25, change: 2.15, changePercent: 1.45, ... }
-```
+### 1) TwelveData
+- Input for `get`:
+  - `symbol` (string): e.g., `"AAPL"`, `"MSFT"`, `"SPY"`
+- Output for `get` (current price):
+  ```json
+  {
+    "symbol": "AAPL",
+    "price": 150.25,
+    "timestamp": "2024-01-15T10:30:00.000Z",
+    "source": "twelvedata"
+  }
+  ```
+- Input for `getQuote`:
+  - `symbol` (string): e.g., `"AAPL"`
+- Output for `getQuote` (detailed):
+  ```json
+  {
+    "symbol": "AAPL",
+    "name": "Apple Inc.",
+    "price": 150.25,
+    "change": 2.15,
+    "changePercent": 1.45,
+    "volume": 45000000,
+    "high": 152.10,
+    "low": 148.50,
+    "open": 149.80,
+    "previousClose": 148.10,
+    "timestamp": "2024-01-15T10:30:00.000Z",
+    "source": "twelvedata"
+  }
+  ```
 
-### Available Methods
+Notes:
+- Requires `TWELVEDATA_API_KEY`.
+- Some symbols (e.g., indices) may require paid plans; ETFs like `SPY` typically work on the free tier.
 
-- `get(source, symbol, options)` - Get basic data (current price by default)
-- `getQuote(source, symbol)` - Get detailed quote information
-- `getAvailableSources()` - Get list of available API sources
-- `addSource(name, apiInstance)` - Add a new API source
+### 2) Open‑Meteo (Current Weather)
+- Inputs accepted by `get('openmeteo', ...)`:
+  - Place name (string), e.g., `"stockholm"`, `"barcelona"`
+  - Coordinates object: `{ latitude: number, longitude: number, name?: string }`
+- Output:
+  ```json
+  {
+    "location": "Stockholm",
+    "latitude": 59.32938,
+    "longitude": 18.06871,
+    "temperatureC": 17.5,
+    "windSpeedMps": 7.6,
+    "windDirectionDeg": 87,
+    "weatherCode": 3,
+    "weather": "overcast",
+    "timestamp": "2025-09-09T07:15",
+    "source": "openmeteo"
+  }
+  ```
 
-### Supported Sources
+Notes:
+- No API key required.
+- `weather` is a simplified label derived from Open‑Meteo weather codes: e.g., `clear`, `overcast`, `raining`, `snowing`, etc.
 
-- **twelvedata** - Stock market data (prices, quotes, etc.)
+### 3) Google News (RSS)
+- Inputs accepted by `get('googlenews', ...)`:
+  - Query string, e.g., `"Apple"`, or
+  - Options object: `{ q: string, lang?: string, country?: string, max?: number }`
+    - `lang` defaults to `en`, `country` defaults to `US`, `max` defaults to `10`
+- Output:
+  ```json
+  {
+    "query": "Apple",
+    "lang": "en",
+    "country": "US",
+    "items": [
+      { "title": "...", "link": "https://...", "published": "2025-09-08T12:01:00.000Z", "source": "...", "snippet": "..." }
+    ],
+    "total": 5,
+    "source": "googlenews"
+  }
+  ```
 
-## Examples
+Notes:
+- Uses public Google News RSS endpoint; no API key required.
+- Results depend on locale (`lang`, `country`).
 
-Run the example file to see the library in action:
-
-```bash
-node example.js
-```
-
-## API Response Format
-
-### Current Price Response
-```javascript
-{
-  symbol: 'AAPL',
-  price: 150.25,
-  timestamp: '2024-01-15T10:30:00.000Z',
-  source: 'twelvedata'
-}
-```
-
-### Quote Response
-```javascript
-{
-  symbol: 'AAPL',
-  name: 'Apple Inc.',
-  price: 150.25,
-  change: 2.15,
-  changePercent: 1.45,
-  volume: 45000000,
-  high: 152.10,
-  low: 148.50,
-  open: 149.80,
-  previousClose: 148.10,
-  timestamp: '2024-01-15T10:30:00.000Z',
-  source: 'twelvedata'
-}
-```
-
-## Error Handling
-
-The library includes comprehensive error handling:
-
-```javascript
-try {
-  const data = await dumbAPISources.get('twelvedata', 'AAPL');
-} catch (error) {
-  console.error('Error:', error.message);
-}
-```
-
-Common errors:
-- Missing API key
-- Invalid symbol
-- Network issues
-- API rate limits
+## Available Methods
+- `get(source, query, options?)`
+- `getQuote(source, symbol)` (TwelveData)
+- `getAvailableSources()`
+- `addSource(name, apiInstance)`
 
 ## Development
 
-### Project Structure
-
+Project structure:
 ```
 src/
-├── index.js          # Main library interface
+├── index.js              # Main library interface
 └── apis/
-    └── twelvedata.js # TwelveData API client
+    ├── twelvedata.js     # Stocks (TwelveData)
+    ├── openmeteo.js      # Weather (Open‑Meteo)
+    └── googlenews.js     # News (Google News RSS)
 ```
 
-### Adding New API Sources
-
-To add a new API source, create a new file in `src/apis/` and implement the required methods. Then add it to the main class in `src/index.js`.
-
 ## License
-
 MIT

--- a/example.js
+++ b/example.js
@@ -32,30 +32,31 @@ async function example() {
     console.log('');
     */
 
-    // Example 3: Get current price for S&P500:w 
+    // Example 2: Get current price for S&P 500 ETF (SPY)
+
     console.log('💻 Getting current price for S&P 500 ETF (SPY)...');
     const spxPrice = await api.get('twelvedata', 'SPY');
     console.log('S&P 500 current price:', spxPrice);
     console.log('');
 
-    // Weather examples via Open-Meteo
-    console.log('🌤️ Getting current weather for Stockholm...');
+    // Example 3: Weather examples via Open-Meteo
+    console.log('🌤️ (3a) Getting current weather for Stockholm...');
     const stockholmWeather = await api.get('openmeteo', 'stockholm');
     console.log('Stockholm weather:', stockholmWeather);
     console.log('');
 
-    console.log('🌤️ Getting current weather for New York via coordinates...');
+    console.log('🌤️ (3b) Getting current weather for New York via coordinates...');
     const nycWeather = await api.get('openmeteo', { latitude: 40.7128, longitude: -74.0060, name: 'New York' });
     console.log('New York weather:', nycWeather);
     console.log('');
 
-    // Google News example
+    // Example 4: Google News example
     console.log('🗞️ Getting Google News headlines for Apple...');
     const gn = await api.get('googlenews', { q: 'Apple', lang: 'en', country: 'US', max: 5 });
     console.log('Google News (Apple):', gn);
     console.log('');
 
-    // Example 4: Error handling
+    // Example 5: Error handling
     console.log('❌ Testing error handling with invalid symbol...');
     try {
       await api.get('twelvedata', 'INVALID_SYMBOL_12345');
@@ -64,7 +65,7 @@ async function example() {
     }
     console.log('');
 
-    // Example 5: Testing unsupported source
+    // Example 6: Testing unsupported source
     console.log('❌ Testing unsupported source...');
     try {
       await api.get('unsupported', 'AAPL');


### PR DESCRIPTION
This PR updates README with input/output documentation and examples for all supported sources:\n\n- TwelveData: get() and getQuote() inputs/outputs, API key notes\n- Open‑Meteo: place name and coordinates inputs, normalized output incl. simplified weather label\n- Google News: query/options inputs (q, lang, country, max), normalized output\n\nAlso includes expanded quick-start usage and project structure.